### PR TITLE
DependentSelect methods corrected

### DIFF
--- a/ru/form-element.md
+++ b/ru/form-element.md
@@ -529,8 +529,12 @@ AdminFormElement::dependentselect(string $key, string $label = null, array $depe
 Указание ключей полей, при изменении значения в которых производить обновление текущего поля
 
 <a name="dependentselect-setModelForOptions"></a>
-#### `setModelForOptions(string|\Illuminate\Database\Eloquent\Model $model, string $titleKey = null): static`
+#### `setModelForOptions(string|\Illuminate\Database\Eloquent\Model $model): static`
 Указание модели, которая будет использована в качестве элементов списка.
+
+<a name="dependentselect-setDisplay"></a>
+#### `setDisplay(string $titleKey): static`
+Указание поля модели, используемого в качестве заголовка
 
 <a name="dependentselect-setLoadOptionsQueryPreparer"></a>
 #### `setLoadOptionsQueryPreparer(Closure $callback): static`


### PR DESCRIPTION
https://github.com/LaravelRUS/SleepingOwlAdmin/issues/517

> В `dependentselect` не отображается `$titleKey`, если использовать метод `setModelForOptions()`, как описано в доке: https://sleepingowladmin.ru/docs/form-element#dependentselect-setModelForOptions
> 
> Если не указывать `$titleKey` в `setModelForOptions()`, а задать его через `setDisplay()` (не документированный метод для `dependselect`, поэтому ссылка на `select` https://sleepingowladmin.ru/docs/form-element#select-setDisplay), то всё работает!
> 
> В вашем демо проекте также используется `setDisplay`: https://github.com/SleepingOwlAdmin/demo/blob/master/admin/Http/Sections/Form.php#L94
> 
> ```
> AdminFormElement::dependentselect('city_id', 'City', ['select'])->setModelForOptions(\App\Model\Country::class)
>     ->setDisplay("title")
>     ->required(),
> ```